### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,18 +1,18 @@
 # Syntax Coloring Map For ModbusIP
 
 # Datatypes (KEYWORD1)
-Valve    	KEYWORD1
+Valve	KEYWORD1
 
 # Methods and Functions (KEYWORD2)
-init        KEYWORD2
-control		KEYWORD2
-lastON      KEYWORD2
-lastOFF		KEYWORD2
-setTime		KEYWORD2
-setRate		KEYWORD2
-Status		KEYWORD2
-Click		KEYWORD2
-Flow		KEYWORD2
+init	KEYWORD2
+control	KEYWORD2
+lastON	KEYWORD2
+lastOFF	KEYWORD2
+setTime	KEYWORD2
+setRate	KEYWORD2
+Status	KEYWORD2
+Click	KEYWORD2
+Flow	KEYWORD2
 
 # Constants (LITERAL1)
 DEBUG_INFO	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords